### PR TITLE
Add certificate management platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-certificados
+# Certificados
+
+Plataforma web para la gestión de certificados regulatorios. Los archivos se encuentran en `src/`.
+
+## Uso
+
+Abra `src/index.html` en su navegador. Se conecta a Supabase utilizando la URL y clave pública proporcionada.
+
+Necesita una tabla llamada `certificados` con los campos:
+
+- `id` (UUID o entero)
+- `lab_name`
+- `address`
+- `product_type`
+- `pharmaceutical_form`
+- `certificate_type`
+- `issue_date` (date)
+- `expiry_date` (date)
+
+La aplicación permite agregar, editar y eliminar certificados, así como filtrar por los distintos campos.

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestión de Certificados</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-XX" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+  <header>
+    <h1>Gestión de Certificados</h1>
+    <button id="addBtn" aria-label="Agregar certificado"><i class="fa fa-plus"></i> Agregar</button>
+  </header>
+
+  <section id="filters">
+    <select id="labFilter"><option value="">Laboratorio</option></select>
+    <select id="typeFilter"><option value="">Tipo de producto</option></select>
+    <select id="formFilter"><option value="">Forma farmacéutica</option></select>
+    <select id="certFilter"><option value="">Tipo de certificado</option></select>
+  </section>
+
+  <div class="table-container">
+    <table id="certTable" aria-label="Certificados">
+      <thead>
+        <tr>
+          <th>Laboratorio</th>
+          <th>Dirección</th>
+          <th>Tipo</th>
+          <th>Forma</th>
+          <th>Certificado</th>
+          <th>Emisión</th>
+          <th>Vencimiento</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <div id="modal" aria-hidden="true">
+    <div class="modal-content" role="dialog" aria-modal="true" tabindex="-1">
+      <form id="certForm">
+        <h2 id="modalTitle">Agregar Certificado</h2>
+        <label>Laboratorio<input type="text" id="lab" required></label>
+        <label>Dirección<input type="text" id="address" required></label>
+        <label>Tipo de producto<input type="text" id="productType" required></label>
+        <label>Forma farmacéutica<input type="text" id="pharmaForm" required></label>
+        <label>Tipo de certificado<input type="text" id="certType" required></label>
+        <label>Fecha de emisión<input type="date" id="issueDate" required></label>
+        <label>Fecha de vencimiento<input type="date" id="expiryDate" required></label>
+        <div class="actions">
+          <button type="submit" id="saveBtn">Guardar</button>
+          <button type="button" id="cancelBtn">Cancelar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/src/script.js
+++ b/src/script.js
@@ -1,0 +1,172 @@
+const supabaseUrl = 'https://yzdjpwdoutjeuuvxmqmv.supabase.co';
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inl6ZGpwd2RvdXRqZXV1dnhtcW12Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1MTg2NTMsImV4cCI6MjA2NTA5NDY1M30.WgC0o1VLVCMTi2cKiGC6OIPHrwgjTA.'; // API Key
+const supabase = supabase.createClient(supabaseUrl, supabaseKey);
+
+let data = [];
+let editingId = null;
+
+async function fetchCertificates() {
+  const { data: rows, error } = await supabase.from('certificados').select('*');
+  if (error) {
+    alert('Error al obtener datos');
+    console.error(error);
+    return;
+  }
+  data = rows;
+  populateFilters();
+  renderTable();
+}
+
+function escapeHTML(str) {
+  return str ? str.replace(/[&<>\'\"]/g, tag => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    "'": '&#39;',
+    '"': '&quot;'
+  }[tag])) : '';
+}
+
+function renderTable() {
+  const tbody = document.querySelector('#certTable tbody');
+  tbody.innerHTML = '';
+  const filters = {
+    lab: document.getElementById('labFilter').value,
+    type: document.getElementById('typeFilter').value,
+    form: document.getElementById('formFilter').value,
+    cert: document.getElementById('certFilter').value
+  };
+  data.filter(row => {
+    return (!filters.lab || row.lab_name === filters.lab) &&
+           (!filters.type || row.product_type === filters.type) &&
+           (!filters.form || row.pharmaceutical_form === filters.form) &&
+           (!filters.cert || row.certificate_type === filters.cert);
+  }).forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${escapeHTML(row.lab_name)}</td>
+      <td>${escapeHTML(row.address)}</td>
+      <td>${escapeHTML(row.product_type)}</td>
+      <td>${escapeHTML(row.pharmaceutical_form)}</td>
+      <td>${escapeHTML(row.certificate_type)}</td>
+      <td>${escapeHTML(row.issue_date)}</td>
+      <td>${escapeHTML(row.expiry_date)}</td>
+      <td>
+        <button class="actions-btn edit" data-id="${row.id}" aria-label="Editar"><i class="fa fa-edit"></i></button>
+        <button class="actions-btn delete" data-id="${row.id}" aria-label="Eliminar"><i class="fa fa-trash"></i></button>
+      </td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function populateFilters() {
+  const labs = new Set();
+  const types = new Set();
+  const forms = new Set();
+  const certs = new Set();
+  data.forEach(row => {
+    labs.add(row.lab_name);
+    types.add(row.product_type);
+    forms.add(row.pharmaceutical_form);
+    certs.add(row.certificate_type);
+  });
+  fillSelect('labFilter', labs);
+  fillSelect('typeFilter', types);
+  fillSelect('formFilter', forms);
+  fillSelect('certFilter', certs);
+}
+
+function fillSelect(id, values) {
+  const select = document.getElementById(id);
+  const current = select.value;
+  const first = select.options[0].textContent;
+  select.innerHTML = `<option value="">${first}</option>`;
+  [...values].sort().forEach(v => {
+    select.innerHTML += `<option value="${escapeHTML(v)}">${escapeHTML(v)}</option>`;
+  });
+  select.value = current;
+}
+
+// Event listeners
+
+document.getElementById('addBtn').addEventListener('click', () => openModal());
+document.getElementById('cancelBtn').addEventListener('click', closeModal);
+document.getElementById('certForm').addEventListener('submit', saveCert);
+['labFilter','typeFilter','formFilter','certFilter'].forEach(id => {
+  document.getElementById(id).addEventListener('change', renderTable);
+});
+
+document.querySelector('#certTable tbody').addEventListener('click', e => {
+  if (e.target.closest('.edit')) {
+    const id = e.target.closest('button').dataset.id;
+    editCert(id);
+  } else if (e.target.closest('.delete')) {
+    const id = e.target.closest('button').dataset.id;
+    deleteCert(id);
+  }
+});
+
+function openModal(cert = null) {
+  const modal = document.getElementById('modal');
+  modal.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
+  modal.querySelector('#modalTitle').textContent = cert ? 'Editar Certificado' : 'Agregar Certificado';
+  document.getElementById('certForm').reset();
+  editingId = cert ? cert.id : null;
+  if (cert) {
+    document.getElementById('lab').value = cert.lab_name;
+    document.getElementById('address').value = cert.address;
+    document.getElementById('productType').value = cert.product_type;
+    document.getElementById('pharmaForm').value = cert.pharmaceutical_form;
+    document.getElementById('certType').value = cert.certificate_type;
+    document.getElementById('issueDate').value = cert.issue_date;
+    document.getElementById('expiryDate').value = cert.expiry_date;
+  }
+  modal.querySelector('.modal-content').focus();
+}
+
+function closeModal() {
+  document.getElementById('modal').setAttribute('aria-hidden', 'true');
+  document.body.style.overflow = '';
+  editingId = null;
+}
+
+async function saveCert(event) {
+  event.preventDefault();
+  const fields = {
+    lab_name: document.getElementById('lab').value.trim(),
+    address: document.getElementById('address').value.trim(),
+    product_type: document.getElementById('productType').value.trim(),
+    pharmaceutical_form: document.getElementById('pharmaForm').value.trim(),
+    certificate_type: document.getElementById('certType').value.trim(),
+    issue_date: document.getElementById('issueDate').value,
+    expiry_date: document.getElementById('expiryDate').value
+  };
+  if (editingId) {
+    const { error } = await supabase.from('certificados').update(fields).eq('id', editingId);
+    if (error) return alert('Error al actualizar');
+  } else {
+    const { error } = await supabase.from('certificados').insert(fields);
+    if (error) return alert('Error al insertar');
+  }
+  closeModal();
+  fetchCertificates();
+}
+
+function editCert(id) {
+  const cert = data.find(r => String(r.id) === String(id));
+  if (cert) openModal(cert);
+}
+
+async function deleteCert(id) {
+  if (!confirm('¿Eliminar certificado?')) return;
+  const { error } = await supabase.from('certificados').delete().eq('id', id);
+  if (error) {
+    alert('Error al eliminar');
+  } else {
+    fetchCertificates();
+  }
+}
+
+fetchCertificates();

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,140 @@
+:root {
+  --lavender: #CDB4DB;
+  --pink: #FFC8DD;
+  --salmon: #FFAFCC;
+  --light-blue: #BDE0FE;
+  --blue: #A2D2FF;
+  --text: #333;
+  --bg: #fff;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  font-family: 'Roboto', sans-serif;
+  margin: 0;
+  background: var(--light-blue);
+  color: var(--text);
+}
+header {
+  background: var(--blue);
+  color: var(--bg);
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+header h1 {
+  margin: 0;
+}
+header button {
+  background: var(--pink);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 1rem;
+}
+header button:hover {
+  background: var(--salmon);
+}
+#filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+#filters select {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--lavender);
+  background: var(--bg);
+}
+.table-container {
+  padding: 1rem;
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--lavender);
+  text-align: left;
+}
+tr:nth-child(even) {
+  background: var(--bg);
+}
+tr:hover {
+  background: var(--pink);
+}
+.actions-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--blue);
+  font-size: 1rem;
+}
+.actions-btn:hover {
+  color: var(--salmon);
+}
+#modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+#modal[aria-hidden="false"] {
+  display: flex;
+}
+.modal-content {
+  background: var(--bg);
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  animation: fadeIn 0.3s ease;
+}
+.modal-content form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.modal-content label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 700;
+}
+.modal-content input {
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--lavender);
+}
+.modal-content .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+.modal-content button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#saveBtn {
+  background: var(--blue);
+  color: var(--bg);
+}
+#cancelBtn {
+  background: var(--salmon);
+  color: var(--bg);
+}
+@keyframes fadeIn {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}


### PR DESCRIPTION
## Summary
- add responsive certificate management web app in `src/`
- implement Supabase connection, CRUD actions, and filters
- style with pastel palette and accessible components
- update README with basic usage instructions

## Testing
- `npm test` *(fails: ENOENT because package.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847944968ec832b8f463f71a0aaa581