### PR TITLE
Improve table layout for small screens

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -98,21 +98,21 @@ function renderTable() {
 
     return `
       <tr class="${rowClass} hover:bg-blue-50">
-        <td class="px-4 py-2 whitespace-nowrap">${row.laboratorio || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.direccion || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.pais || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.tipo_producto || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.tipo_formafarmaceutica || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.tipo_forma || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.tipo_certificado || ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.fecha_emision ? formatDate(row.fecha_emision) : ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.fecha_vencimiento ? formatDate(row.fecha_vencimiento) : ''}</td>
-        <td class="px-4 py-2 whitespace-nowrap space-x-2">
+        <td class="px-3 py-2 break-words">${row.laboratorio || ''}</td>
+        <td class="px-3 py-2 break-words">${row.direccion || ''}</td>
+        <td class="px-3 py-2">${row.pais || ''}</td>
+        <td class="px-3 py-2 break-words">${row.tipo_producto || ''}</td>
+        <td class="px-3 py-2 break-words">${row.tipo_formafarmaceutica || ''}</td>
+        <td class="px-3 py-2 break-words">${row.tipo_forma || ''}</td>
+        <td class="px-3 py-2 break-words">${row.tipo_certificado || ''}</td>
+        <td class="px-3 py-2">${row.fecha_emision ? formatDate(row.fecha_emision) : ''}</td>
+        <td class="px-3 py-2">${row.fecha_vencimiento ? formatDate(row.fecha_vencimiento) : ''}</td>
+        <td class="px-3 py-2 space-x-2">
           <button class="bg-blue-500 text-white px-2 py-1 rounded shadow hover:bg-blue-600 transition-colors text-xs" data-action="ver" data-url="${row.archivo_pdf}">Ver</button>
           <button class="bg-green-500 text-white px-2 py-1 rounded shadow hover:bg-green-600 transition-colors text-xs" data-action="descargar" data-url="${row.archivo_pdf}">Descargar</button>
         </td>
-        <td class="px-4 py-2 whitespace-nowrap font-semibold">${icono} ${estado}</td>
-        <td class="px-4 py-2 whitespace-nowrap">${row.fecha_agregado ? formatDate(row.fecha_agregado) : ''}</td>
+        <td class="px-3 py-2 font-semibold">${icono} ${estado}</td>
+        <td class="px-3 py-2">${row.fecha_agregado ? formatDate(row.fecha_agregado) : ''}</td>
       </tr>
     `;
   }).join('');

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id="logoutBtn" class="bg-blue-800 px-3 py-1 rounded">Cerrar sesión</button>
     </header>
 
-    <main class="p-4 overflow-x-auto">
+    <main class="p-4">
       <div class="flex flex-wrap gap-4 mb-4">
         <input id="search" type="text" placeholder="Buscar..." aria-label="Buscar certificados" class="border px-2 py-1 rounded w-full sm:w-auto" />
         <select id="filterPais" aria-label="Filtrar por país" class="border px-2 py-1 rounded">
@@ -34,25 +34,25 @@
 
       <div id="loading" class="text-center" aria-live="polite">Cargando...</div>
 
-      <div class="overflow-x-auto mt-4">
-        <table class="min-w-full text-sm divide-y divide-gray-200">
-          <thead class="bg-gray-100 sticky top-0 z-10">
+      <div class="overflow-x-hidden mt-4">
+        <table class="table-fixed w-full divide-y divide-gray-200 text-sm">
+          <thead class="bg-gray-200 sticky top-0 text-gray-700">
             <tr>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Laboratorio</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Dirección</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">País</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Tipo de Producto</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Tipo de Forma Farmacéutica</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Tipo Forma (Cert)</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Tipo de Certificado</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Fecha de Emisión</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Fecha de Vencimiento</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Archivo PDF</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Estado</th>
-              <th class="px-4 py-3 text-left font-medium text-gray-700 whitespace-nowrap">Fecha que fue actualizado</th>
+              <th class="px-3 py-2 w-32 font-semibold">Laboratorio</th>
+              <th class="px-3 py-2 w-52 break-words">Dirección</th>
+              <th class="px-3 py-2 w-24 font-semibold">País</th>
+              <th class="px-3 py-2 w-40 break-words">Tipo de Producto</th>
+              <th class="px-3 py-2 w-40 break-words">Tipo de Forma Farmacéutica</th>
+              <th class="px-3 py-2 w-36 break-words">Tipo Forma (Cert)</th>
+              <th class="px-3 py-2 w-36 break-words">Tipo de Certificado</th>
+              <th class="px-3 py-2 w-32 font-semibold">Fecha de Emisión</th>
+              <th class="px-3 py-2 w-32 font-semibold">Fecha de Vencimiento</th>
+              <th class="px-3 py-2 w-20 truncate">Archivo PDF</th>
+              <th class="px-3 py-2 w-24 font-semibold">Estado</th>
+              <th class="px-3 py-2 w-36 font-semibold">Fecha Actualizado</th>
             </tr>
           </thead>
-          <tbody id="tableBody"></tbody>
+          <tbody id="tableBody" class="divide-y divide-gray-100"></tbody>
         </table>
       </div>
 


### PR DESCRIPTION
## Summary
- remove horizontal overflow from the dashboard
- fix table headers widths and styling
- adjust row cell classes to wrap long text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68488cc562b8832bbdf0330e680f38d3