### PR TITLE
Display certificate table with state

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="js/supabaseClient.js"></script>
-  <script src="js/index.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script type="module" src="js/index.js"></script>
 </head>
 <body class="min-h-screen flex bg-gray-50">
   <!-- Sidebar -->

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,6 @@
+import { renderTablaCertificados } from './certificados.js';
+const supa = window.supa;
+
 function isAuthorized(email) {
   return (window.ALLOWED_EMAILS || []).includes((email || '').toLowerCase());
 }
@@ -15,7 +18,7 @@ async function loadSession() {
 async function loadCertificados() {
   const { data, error } = await supa
     .from('dataBase')
-    .select('fecha_vencimiento, laboratorio, pais, tipo_certificado, fecha_emision');
+    .select('*');
   if (error) {
     console.error(error);
     return [];
@@ -106,33 +109,13 @@ function setupSidebarNavigation() {
 
       if (tab === 'vencer') {
         const certificados = await loadCertificados();
-        const hoy = new Date();
-        const limite = new Date(hoy.getTime() + 90 * 24 * 60 * 60 * 1000);
-        const proximos = certificados
-          .filter(c => new Date(c.fecha_vencimiento) >= hoy && new Date(c.fecha_vencimiento) <= limite)
-          .sort((a, b) => new Date(a.fecha_vencimiento) - new Date(b.fecha_vencimiento));
-        const tbody = document.getElementById('vencerBody');
-        tbody.innerHTML = '';
-        proximos.forEach(c => {
-          const div = document.createElement('div');
-          div.className = "py-1 border-b";
-          div.innerHTML = `<strong>${c.laboratorio}</strong> | ${c.pais} | ${c.tipo_certificado} | Vence: ${c.fecha_vencimiento}`;
-          tbody.appendChild(div);
-        });
+        renderTablaCertificados(certificados, 'vencerBody');
       }
 
       ['clv', 'cpp', 'cbpm'].forEach(tipo => {
         if (tab === tipo) {
           loadCertificados().then(certificados => {
-            const filtrados = certificados.filter(c => (c.tipo_certificado || '').toLowerCase() === tipo);
-            const contenedor = document.getElementById(`${tipo}Body`);
-            contenedor.innerHTML = '';
-            filtrados.forEach(c => {
-              const div = document.createElement('div');
-              div.className = "py-1 border-b";
-              div.innerHTML = `<strong>${c.laboratorio}</strong> | ${c.pais} | ${c.tipo_certificado} | Vence: ${c.fecha_vencimiento}`;
-              contenedor.appendChild(div);
-            });
+            renderTablaCertificados(certificados, `${tipo}Body`);
           });
         }
       });


### PR DESCRIPTION
## Summary
- convert dashboard script to ES module
- fetch all certificate fields from Supabase
- show certificate table in CLV/CPP/CBPM and Por Vencer tabs
- include SheetJS for Excel export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848e7023c08832b8a0378c32d1a5f1e